### PR TITLE
Fix pictogram selection bug in sentence bar

### DIFF
--- a/script.js
+++ b/script.js
@@ -197,7 +197,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const deleteBtn = document.createElement('button');
         deleteBtn.className = 'delete-btn';
         deleteBtn.innerHTML = '&times;';
-        deleteBtn.setAttribute('aria-label', `Eliminar ${pictogram.text}`);
+        deleteBtn.setAttribute('aria-label', `Eliminar ${variation.text}`);
         deleteBtn.addEventListener('click', (e) => {
             e.stopPropagation();
             sentencePictogram.remove();


### PR DESCRIPTION
The `addToSentence` function was trying to access the `pictogram.text` variable, which was not in scope. This caused a `ReferenceError` and prevented pictograms from being added to the sentence bar.

This commit fixes the bug by using `variation.text` instead, which is available in the function's scope.