### PR TITLE
fix(js): Correct variable in addToSentence function

### DIFF
--- a/script.js
+++ b/script.js
@@ -197,7 +197,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const deleteBtn = document.createElement('button');
         deleteBtn.className = 'delete-btn';
         deleteBtn.innerHTML = '&times;';
-        deleteBtn.setAttribute('aria-label', `Eliminar ${pictogram.text}`);
+        deleteBtn.setAttribute('aria-label', `Eliminar ${variation.text}`);
         deleteBtn.addEventListener('click', (e) => {
             e.stopPropagation();
             sentencePictogram.remove();


### PR DESCRIPTION
The `addToSentence` function in `script.js` was using an undefined variable `pictogram` when setting the `aria-label` for the delete button. This caused a `ReferenceError` which stopped the function's execution before the selected pictogram could be appended to the sentence bar.

This commit fixes the issue by replacing `pictogram.text` with `variation.text`, which is available in the function's scope and contains the correct text for the selected pictogram variation.