### PR TITLE
fix(css): Ensure text wraps correctly in category cards

### DIFF
--- a/style.css
+++ b/style.css
@@ -86,6 +86,9 @@ h1, h2 {
     margin-top: 1rem;
     font-size: 1rem;
     font-weight: 500;
+    white-space: normal;
+    word-wrap: break-word;
+    min-height: 2.5em;
 }
 
 .sentence-container {


### PR DESCRIPTION
This commit fixes an issue where long category names would overflow their cards instead of wrapping.

- Modified the `.pictogram-card p` selector in `style.css`.
- Explicitly set `white-space: normal` and `word-wrap: break-word`.
- Added a `min-height` to the paragraph element to ensure there is enough space for two lines of text.

This ensures that all category names are fully visible and readable.